### PR TITLE
Fix: Add nil check for context in SaveConfContext

### DIFF
--- a/config.go
+++ b/config.go
@@ -58,6 +58,9 @@ func LoadConfContext[T any](ctx context.Context) (T, error) {
 
 // SaveConfContext saves the given type to the configuration file.
 func SaveConfContext(ctx context.Context) error {
+	if ctx == nil {
+		return errors.New("context is nil")
+	}
 	name, marshaler, err := extractContextValues(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR fixes a bug where `SaveConfContext` would panic if a nil context was passed to it.

**Changes:**
- Added a nil check at the beginning of `SaveConfContext` function
- Returns a descriptive error message if context is nil

**Before:**
```go
func SaveConfContext(ctx context.Context) error {
    name, marshaler, err := extractContextValues(ctx)
    // ...
}
```

**After:**
```go
func SaveConfContext(ctx context.Context) error {
    if ctx == nil {
        return errors.New("context is nil")
    }
    name, marshaler, err := extractContextValues(ctx)
    // ...
}
```

This prevents a panic when calling `ctx.Value()` on a nil context.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.